### PR TITLE
build(deps): bump react and @types/react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@vercel/speed-insights": "^1.2.0",
         "dotenv": "^17.2.1",
         "next": "15.4.3",
-        "react": "19.1.0",
+        "react": "19.1.1",
         "react-dom": "19.1.0"
       },
       "devDependencies": {
@@ -1334,10 +1334,11 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.9.tgz",
+      "integrity": "sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4998,9 +4999,10 @@
       ]
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@vercel/speed-insights": "^1.2.0",
     "dotenv": "^17.2.1",
     "next": "15.4.3",
-    "react": "19.1.0",
+    "react": "19.1.1",
     "react-dom": "19.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dotenv": "^17.2.1",
     "next": "15.4.3",
     "react": "19.1.1",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
Bumps [react](https://github.com/facebook/react/tree/HEAD/packages/react) and [@types/react](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/react). These dependencies needed to be updated together.

Updates `react` from 19.1.0 to 19.1.1
- [Release notes](https://github.com/facebook/react/releases)
- [Changelog](https://github.com/facebook/react/blob/main/CHANGELOG.md)
- [Commits](https://github.com/facebook/react/commits/v19.1.1/packages/react)

Updates `@types/react` from 19.1.8 to 19.1.9
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/react)

---
updated-dependencies:
- dependency-name: react dependency-version: 19.1.1 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: "@types/react" dependency-version: 19.1.9 dependency-type: direct:development update-type: version-update:semver-patch ...